### PR TITLE
Earlier permissions registration and better world change handling.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <url>http://maven.apache.org</url>
 
   <scm>
-    <connection>scm:hg:</connection>
+    <connection>scm:git:</connection>
   </scm>
 
   <properties>

--- a/src/main/java/org/tyrannyofheaven/bukkit/zPermissions/ZPermissionsPlayerListener.java
+++ b/src/main/java/org/tyrannyofheaven/bukkit/zPermissions/ZPermissionsPlayerListener.java
@@ -18,7 +18,8 @@ package org.tyrannyofheaven.bukkit.zPermissions;
 import static org.tyrannyofheaven.bukkit.util.ToHUtils.registerEvent;
 
 import org.bukkit.event.Event.Priority;
-import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerListener;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -39,9 +40,11 @@ class ZPermissionsPlayerListener extends PlayerListener {
     }
 
     void registerEvents(boolean regionSupport) {
-        registerEvent("PLAYER_JOIN", this, Priority.Monitor, plugin);
+        registerEvent("PLAYER_LOGIN", this, Priority.Lowest, plugin);
         registerEvent("PLAYER_QUIT", this, Priority.Monitor, plugin);
-        registerEvent("PLAYER_TELEPORT", this, Priority.Monitor, plugin);
+        if (!registerEvent("PLAYER_CHANGED_WORLD", this, Priority.Lowest, plugin)) {
+            registerEvent("PLAYER_TELEPORT", this, Priority.Monitor, plugin);
+        }
 
         // Only check PLAYER_MOVE if region support is enabled
         if (regionSupport)
@@ -49,8 +52,8 @@ class ZPermissionsPlayerListener extends PlayerListener {
     }
 
     @Override
-    public void onPlayerJoin(PlayerJoinEvent event) {
-        plugin.updateAttachment(event.getPlayer().getName(), event.getPlayer().getLocation(), true);
+    public void onPlayerLogin(PlayerLoginEvent event) {
+        plugin.updateAttachment(event.getPlayer(), event.getPlayer().getLocation(), true, true);
     }
 
     @Override
@@ -63,7 +66,7 @@ class ZPermissionsPlayerListener extends PlayerListener {
         if (event.isCancelled()) return;
 
         // Conditionally update if world changed
-        plugin.updateAttachment(event.getPlayer().getName(), event.getTo(), false);
+        plugin.updateAttachment(event.getPlayer(), event.getTo(), false, false);
     }
 
     @Override
@@ -75,8 +78,13 @@ class ZPermissionsPlayerListener extends PlayerListener {
                 event.getFrom().getBlockY() != event.getTo().getBlockY() ||
                 event.getFrom().getBlockZ() != event.getTo().getBlockZ()) {
             // Conditionally update if containing regions changed
-            plugin.updateAttachment(event.getPlayer().getName(), event.getTo(), false);
+            plugin.updateAttachment(event.getPlayer(), event.getTo(), false, false);
         }
+    }
+
+    @Override
+    public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
+        plugin.updateAttachment(event.getPlayer(), event.getPlayer().getLocation(), false, false);
     }
 
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ database: true
 commands:
   permissions:
     description: Top-level command for zPermissions
-    aliases: [perm, p]
+    aliases: [perm, perms, p]
   promote:
     description: Promote a player up a rank
     aliases: rankup


### PR DESCRIPTION
These are some issues I found while I was trying out the plugin earlier. Another thing that bugged me a bit was how groups are automatically created (I'm very good at making typos). I'd prefer if groups had to be explicitly created to reduce accidental group creation.
