### PR TITLE
Add Bukkit repository to fix builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,10 @@
 
   <repositories>
     <repository>
+      <id>bukkit-repo</id>
+      <url>http://repo.bukkit.org/content/groups/public</url>
+    </repository>
+    <repository>
       <id>tyrannyofheaven.org</id>
       <url>http://maven.tyrannyofheaven.org</url>
     </repository>


### PR DESCRIPTION
```
[ERROR] Failed to execute goal on project zPermissions: Could not resolve dependencies for project org.tyrannyofheaven.bukkit:zPermissions:jar:1.1-SNAPSHOT: Could not find artifact org.bukkit:bukkit:jar:1.6.2-R1.1-SNAPSHOT in tyrannyofheaven.org (http://maven.tyrannyofheaven.org) -> [Help 1]
```

This PR fixes it.
